### PR TITLE
Fixed AVX-512 intrinsic layer (sparse_matmul_op.h). Incorporated LIBXSMM_DNN_CONV_OPTION_OVERWRITE.

### DIFF
--- a/tensorflow/core/kernels/conv_grad_input_ops.cc
+++ b/tensorflow/core/kernels/conv_grad_input_ops.cc
@@ -174,7 +174,7 @@ struct LaunchXsmmBackwardInputConvolution<CPUDevice, float> {
     desc.filter_format =
         LIBXSMM_DNN_TENSOR_FORMAT_LIBXSMM;  // LIBXSMM_DNN_TENSOR_FORMAT_RSCK;
     desc.fuse_ops = LIBXSMM_DNN_CONV_FUSE_NONE;
-    desc.options = LIBXSMM_DNN_CONV_OPTION_WU_EXT_FILTER_REDUCE;
+    desc.options = (libxsmm_dnn_conv_option)(LIBXSMM_DNN_CONV_OPTION_WU_EXT_FILTER_REDUCE | LIBXSMM_DNN_CONV_OPTION_OVERWRITE);
     desc.datatype = LIBXSMM_DNN_DATATYPE_F32;
 
     auto input_ptr = input_backward.data();

--- a/tensorflow/core/kernels/conv_ops.cc
+++ b/tensorflow/core/kernels/conv_ops.cc
@@ -222,7 +222,7 @@ class LaunchXsmmConvOp<CPUDevice, float> {
     desc.buffer_format = LIBXSMM_DNN_TENSOR_FORMAT_NHWC;
     desc.filter_format = LIBXSMM_DNN_TENSOR_FORMAT_LIBXSMM;
     desc.fuse_ops = LIBXSMM_DNN_CONV_FUSE_NONE;
-    desc.options = LIBXSMM_DNN_CONV_OPTION_WU_EXT_FILTER_REDUCE;
+    desc.options = (libxsmm_dnn_conv_option)(LIBXSMM_DNN_CONV_OPTION_WU_EXT_FILTER_REDUCE | LIBXSMM_DNN_CONV_OPTION_OVERWRITE);
     desc.datatype = LIBXSMM_DNN_DATATYPE_F32;
 
     if (!CanUseXsmmConv2D(desc, data_format)) {

--- a/tensorflow/core/kernels/sparse_matmul_op.h
+++ b/tensorflow/core/kernels/sparse_matmul_op.h
@@ -31,11 +31,11 @@ namespace internal {
 // in the lower 16-bits of input
 template <typename Packet>
 EIGEN_DEVICE_FUNC inline Packet pexpand_bf16_l(const Packet& from) {
-  tensorflow::uint32 tmp;  
+  tensorflow::uint32 tmp;
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-    tmp = (reinterpret_cast<const tensorflow::uint32&>(from) ) & 0xffff0000;  
-#else    
-    tmp = (reinterpret_cast<const tensorflow::uint32&>(from) << 16) & 0xffff0000;  
+  tmp = (reinterpret_cast<const tensorflow::uint32&>(from)) & 0xffff0000;
+#else
+  tmp = (reinterpret_cast<const tensorflow::uint32&>(from) << 16) & 0xffff0000;
 #endif
   return reinterpret_cast<const float&>(tmp);
 }
@@ -44,12 +44,12 @@ EIGEN_DEVICE_FUNC inline Packet pexpand_bf16_l(const Packet& from) {
 // in the upper 16-bits of input
 template <typename Packet>
 EIGEN_DEVICE_FUNC inline Packet pexpand_bf16_u(const Packet& from) {
-  tensorflow::uint32 tmp;  
+  tensorflow::uint32 tmp;
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-    tmp = (reinterpret_cast<const tensorflow::uint32&>(from) << 16 ) & 0xffff0000;  
+  tmp = (reinterpret_cast<const tensorflow::uint32&>(from) << 16) & 0xffff0000;
 #else
-    tmp = (reinterpret_cast<const tensorflow::uint32&>(from)) & 0xffff0000;  
-#endif 
+  tmp = (reinterpret_cast<const tensorflow::uint32&>(from)) & 0xffff0000;
+#endif
   return reinterpret_cast<const float&>(tmp);
 }
 
@@ -61,12 +61,12 @@ EIGEN_DEVICE_FUNC inline Packet4f pexpand_bf16_l(const Packet4f& from) {
   float r[4];
   tensorflow::uint32 p[4];
   pstoreu(r, from);
-  tensorflow::uint32 * ir = reinterpret_cast<tensorflow::uint32 *>(r);
+  tensorflow::uint32* ir = reinterpret_cast<tensorflow::uint32*>(r);
   p[0] = (ir[0] << 16) & 0xffff0000;
-  p[1] = ir[0]& 0xffff0000;
+  p[1] = ir[0] & 0xffff0000;
   p[2] = (ir[1] << 16) & 0xffff0000;
   p[3] = ir[1] & 0xffff0000;
-  return ploadu<Packet4f>(reinterpret_cast<float *>(p));
+  return ploadu<Packet4f>(reinterpret_cast<float*>(p));
 }
 
 template <typename Packet>
@@ -74,12 +74,12 @@ EIGEN_DEVICE_FUNC inline Packet4f pexpand_bf16_u(const Packet4f& from) {
   float r[4];
   tensorflow::uint32 p[4];
   pstoreu(r, from);
-  tensorflow::uint32 * ir = reinterpret_cast<tensorflow::uint32 *>(r);
+  tensorflow::uint32* ir = reinterpret_cast<tensorflow::uint32*>(r);
   p[0] = (ir[2] << 16) & 0xffff0000;
   p[1] = ir[2] & 0xffff0000;
   p[2] = (ir[3] << 16) & 0xffff0000;
   p[3] = ir[3] & 0xffff0000;
-  return ploadu<Packet4f>(reinterpret_cast<float *>(p));
+  return ploadu<Packet4f>(reinterpret_cast<float*>(p));
 }
 #endif
 
@@ -131,23 +131,25 @@ EIGEN_DEVICE_FUNC inline Packet pload2bf16(
 template <>
 EIGEN_STRONG_INLINE Packet4f pload4bf16<Packet4f>(const float* from) {
   tensorflow::uint32 p[4];
-  const tensorflow::uint32* ir = reinterpret_cast<const tensorflow::uint32 *>(from);
+  const tensorflow::uint32* ir =
+      reinterpret_cast<const tensorflow::uint32*>(from);
   p[0] = (ir[0] << 16) & 0xffff0000;
-  p[1] = ir[0]& 0xffff0000;
+  p[1] = ir[0] & 0xffff0000;
   p[2] = (ir[1] << 16) & 0xffff0000;
   p[3] = ir[1] & 0xffff0000;
-  return ploadu<Packet4f>(reinterpret_cast<float *>(p));
+  return ploadu<Packet4f>(reinterpret_cast<float*>(p));
 }
 
 template <>
 EIGEN_STRONG_INLINE Packet4f pload2bf16<Packet4f>(const float* from) {
   tensorflow::uint32 p[4];
-  const tensorflow::uint32* ir = reinterpret_cast<const tensorflow::uint32 *>(from);
+  const tensorflow::uint32* ir =
+      reinterpret_cast<const tensorflow::uint32*>(from);
   p[0] = (ir[0] << 16) & 0xffff0000;
-  p[1] = ir[0]& 0xffff0000;
+  p[1] = ir[0] & 0xffff0000;
   p[2] = (ir[0] << 16) & 0xffff0000;
   p[3] = ir[0] & 0xffff0000;
-  return ploadu<Packet4f>(reinterpret_cast<float *>(p));  
+  return ploadu<Packet4f>(reinterpret_cast<float*>(p));
 }
 #endif
 
@@ -255,12 +257,13 @@ EIGEN_STRONG_INLINE Packet8d pbroadcast_second<Packet8d>(const Packet8d& a_in) {
 }
 template <>
 EIGEN_STRONG_INLINE Packet8d pbroadcast_third<Packet8d>(const Packet8d& a_in) {
-  Packet2d a = _mm512_extractf32x4_ps(a_in, 1);
+  Packet2d a = _mm256_extractf128_pd(_mm512_castpd512_pd256(a_in), 1);
   return _mm512_broadcastsd_pd(a);
 }
 template <>
 EIGEN_STRONG_INLINE Packet8d pbroadcast_fourth<Packet8d>(const Packet8d& a_in) {
-  Packet2d a = _mm_permute_pd(_mm512_extractf32x4_ps(a_in, 1), 3);
+  Packet2d a =
+      _mm_permute_pd(_mm256_extractf128_pd(_mm512_castpd512_pd256(a_in), 1), 3);
   return _mm512_broadcastsd_pd(a);
 }
 template <>
@@ -417,14 +420,17 @@ EIGEN_STRONG_INLINE Packet8f pbroadcast_fourth<Packet8f>(const Packet8f& a) {
 
 template <typename Packet>
 EIGEN_DEVICE_FUNC inline Packet16f pexpand_bf16_l(const Packet16f& from) {
-  return _mm512_slli_epi32(_mm512_cvtepu16_epi32(_mm512_castsi512_si256(from)),
-                           16);
+  return _mm512_castsi512_ps(_mm512_slli_epi32(
+      _mm512_cvtepu16_epi32(_mm512_castsi512_si256(_mm512_castps_si512(from))),
+      16));
 }
 
 template <typename Packet>
 EIGEN_DEVICE_FUNC inline Packet16f pexpand_bf16_u(const Packet16f& from) {
-  return _mm512_slli_epi32(
-      _mm512_cvtepu16_epi32(_mm512_extractf64x4_pd(from, 1)), 16);
+  Packet16i tmp = _mm512_castps_si512(from);
+  Packet16i tmp2 = _mm512_alignr_epi32(tmp, tmp, 8);
+  return _mm512_castsi512_ps(_mm512_slli_epi32(
+      _mm512_cvtepu16_epi32(_mm512_castsi512_si256(tmp2)), 16));
 }
 
 #endif

--- a/tensorflow/core/kernels/xsmm_conv2d.cc
+++ b/tensorflow/core/kernels/xsmm_conv2d.cc
@@ -310,8 +310,6 @@ static bool CallLibxsmmConvGeneric(OpKernelContext* ctx,
   chk_libxsmm_err(status, "Link filter");
   }
   if (kind == LIBXSMM_DNN_COMPUTE_KIND_FWD) {
-    chk_libxsmm_err(libxsmm_dnn_zero_buffer(libxsmm_output), "Zero output");
-
     chk_libxsmm_err(libxsmm_dnn_bind_buffer(libxsmm_handle, libxsmm_input, LIBXSMM_DNN_REGULAR_INPUT),
                     "Bind input forward");
     chk_libxsmm_err(


### PR DESCRIPTION
Fixed AVX-512 intrinsic implementation (e.g., when building for Skylake Server [SKX]). Incorporated LIBXSMM_DNN_CONV_OPTION_OVERWRITE option, which omits to zero the buffer when running forward convolutions.